### PR TITLE
Move 'Game Play' responsibility from WebGameCreate into WebGamePlay

### DIFF
--- a/lib/web_app.rb
+++ b/lib/web_app.rb
@@ -4,6 +4,7 @@ require "tictactoe/board_options"
 require "tictactoe/game_type_options"
 require "web_player_factory"
 require "web_game_create"
+require "web_game_play"
 require "web_display"
 require "web_presenter"
 
@@ -19,17 +20,18 @@ class WebApp < Sinatra::Base
 
   get '/game/create' do
     add_params_to_session
-    display = WebDisplay.new
-    web_game = WebGameCreate.new(params, session, WebPlayerFactory.new(display), display)
+    @display = WebDisplay.new
+    web_game = WebGameCreate.new(params, WebPlayerFactory.new(display), display)
+    add_current_board_to_session
     @presenter = WebPresenter.new(web_game)
     erb :game_layout
   end
 
   get '/game/play' do
     add_session_to_params
-    display = WebDisplay.new
-    web_game = WebGameCreate.new(params, session, WebPlayerFactory.new(display), display)
-    web_game.play(params)
+    @display = WebDisplay.new
+    web_game = WebGamePlay.new(params, WebGameCreate.new(params, WebPlayerFactory.new(display), display)).web_game
+    add_current_board_to_session
     @presenter = WebPresenter.new(web_game)
     erb :game_layout
   end
@@ -41,10 +43,15 @@ class WebApp < Sinatra::Base
   def add_session_to_params
     params["game_type"] = session[:game_type]
     params["dimension"] = session[:dimension]
+    params["board_cells"] = session[:board_cells]
   end
 
   def add_params_to_session
     session[:game_type] = params["game_type"]
     session[:dimension] = params["dimension"]
+  end
+
+  def add_current_board_to_session
+    session[:board_cells] = display.board_cells.flatten
   end
 end

--- a/lib/web_display.rb
+++ b/lib/web_display.rb
@@ -16,6 +16,21 @@ class WebDisplay
     @next_move = move
   end
 
+  def display_result
+    if(board.is_game_over?)
+      set_game_state(is_in_play: false)
+      display_win(board.get_winning_mark)
+    end
+  end
+
+  def display_win(mark)
+    @winning_mark = mark
+  end
+
+  def board_cells
+    board.board_cells if !board.nil?
+  end
+
   def ask_for_move
     if has_move?
       return pop_move
@@ -25,10 +40,6 @@ class WebDisplay
 
   def has_move?
     next_move != INVALID_MOVE
-  end
-
-  def display_win(mark)
-    @winning_mark = mark
   end
 
   def set_game_state(is_in_play: true)

--- a/lib/web_game_play.rb
+++ b/lib/web_game_play.rb
@@ -1,0 +1,32 @@
+require "tictactoe/game"
+require "tictactoe/board"
+require "web_game_create"
+
+class WebGamePlay
+  attr_reader :web_game
+
+  def initialize(params, web_game)
+    @next_move = params["position"]
+    @web_game = web_game
+    @display = web_game.display
+    @game = web_game.game
+    play(params)
+  end
+
+  private
+
+  attr_reader :next_move, :display, :game
+
+  def play(params)
+    play_move(params)
+    display.display_result
+  end
+
+  def play_move(params)
+    position = params["position"]
+    if !position.nil?
+      display.display_move(position)
+      game.play_turns
+    end
+  end
+end

--- a/spec/web_app_spec.rb
+++ b/spec/web_app_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe WebApp do
     expect(last_response.body).to include("O")
   end
 
+  it "play a move then 'start again'" do
+    get "/game/create?dimension=THREE_BY_THREE&game_type=HVH"
+    get "/game/play?position=1"
+    get "/"
+    expect(last_response.body).not_to include("X")
+    expect(last_response.body).not_to include("O")
+  end
+
   it "play game till win displayed" do
     get "/game/create?dimension=THREE_BY_THREE&game_type=HVH"
     get "/game/play?position=1"

--- a/spec/web_display_spec.rb
+++ b/spec/web_display_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe WebDisplay do
     expect(display.ask_for_move).to be(WebDisplay::INVALID_MOVE)
   end
 
+  it "display_result displays Winning Announcement " do
+    row1 = ["X", "X", "X"]
+    row2 = ["O", "O", nil]
+    row3 = [nil, nil, nil]
+    winning_board = [ row1, row2, row3 ]
+    board = TicTacToe::Board.new(three_by_three, winning_board)
+    display.display_board(board)
+    expect(display.display_result).to eq(TicTacToe::Mark::X)
+  end
+
   it "receives winning mark" do
     display.set_game_state(is_in_play: false)
     display.display_win(TicTacToe::Mark::X)

--- a/spec/web_game_create_spec.rb
+++ b/spec/web_game_create_spec.rb
@@ -3,85 +3,44 @@ require "tictactoe/board"
 require "tictactoe/board_options"
 require "tictactoe/game_type_options"
 require "web_game_create"
+require "web_game_play"
 require "web_display"
 require "web_player_factory"
 
 RSpec.describe WebGameCreate do
-  let(:three_by_three) { "THREE_BY_THREE" }
   let(:dimension_3) { 3 }
+  let(:three_by_three) { "THREE_BY_THREE" }
   let(:human_v_human) { "HVH" }
   let(:params) { { "dimension"  => three_by_three, "game_type" => human_v_human } }
-  let(:player_factory) { instance_spy(WebPlayerFactory) }
+  let(:player_factory_spy) { instance_spy(WebPlayerFactory) }
   let(:display) { instance_spy(WebDisplay) }
   let(:player1) { instance_spy(WebHumanPlayer) }
   let(:player2) { instance_spy(WebHumanPlayer) }
 
   it "creates a new game based on options" do
-    session_stub = {}
     set_player_ready_state
     allow(display).to receive(:board).and_return(TicTacToe::Board.new(dimension_3))
     allow(display).to receive(:display_board)
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    web_game.play(params)
+    web_game = WebGameCreate.new(params, player_factory_spy, display)
     expect(web_game.ready_to_play?).to eq(true)
   end
 
-  it "plays a move in a specified position" do
-    session_stub = {}
-    set_player_ready_state(player1_is_ready: true)
-    allow(player1).to receive(:get_next_move).and_return(1)
-    allow(display).to receive(:board).and_return(TicTacToe::Board.new(dimension_3))
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    expect(display).to receive(:display_move).with(1)
-    params["position"] = 1
-    web_game.play(params)
-  end
-
-  it "updates session object with board state after a move" do
-    session_stub = {}
-    set_player_ready_state(player1_is_ready: true)
-    allow(player1).to receive(:get_next_move).and_return(1)
-    allow(display).to receive(:board).and_return(TicTacToe::Board.new(dimension_3))
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    params["position"] = 1
-    web_game.play(params)
-    expect(session_stub[:board_cells]).to eq(["X", nil, nil, nil, nil, nil, nil, nil, nil])
-  end
-
-  it "tells web_display game is over" do
-    session_stub = { :board_cells => ["X", "O", "X", "X", "O", "O", "O", "X", "X"] }
-    board = TicTacToe::Board.new(dimension_3, session_stub[:board_cells].each_slice(3).to_a)
+  it "creates a new game using existing board" do
+    set_player_ready_state
+    row1 = ["X", "O", "X"]
+    row2 = [nil, nil, nil]
+    row3 = [nil, nil, nil]
+    board_cells = [row1, row2, row3]
+    params["board_cells"] = board_cells
+    board = TicTacToe::Board.new(dimension_3, board_cells)
     allow(display).to receive(:board).and_return(board)
-    expect(display).to receive(:set_game_state).with(is_in_play: false)
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    params["position"] = 1
-    web_game.play(params)
-  end
-
-  it "tells web_display what the winning mark is " do
-    session_stub = { :board_cells => ["X", "X", "X", "O", "O", 6, 7, 8, 9] }
-    board = TicTacToe::Board.new(dimension_3, session_stub[:board_cells].each_slice(3).to_a)
-    allow(display).to receive(:board).and_return(board)
-    allow(display).to receive(:set_game_state).with(is_in_play: false)
-    expect(display).to receive(:display_win)
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    params["position"] = 1
-    web_game.play(params)
-  end
-
-  it "tells web_display there is a draw " do
-    session_stub = { :board_cells => ["X", "O", "X", "X", "O", "O", "O", "X", "X"] }
-    board = TicTacToe::Board.new(dimension_3, session_stub[:board_cells].each_slice(3).to_a)
-    allow(display).to receive(:board).and_return(board)
-    allow(display).to receive(:set_game_state).with(is_in_play: false)
-    web_game = WebGameCreate.new(params, session_stub, player_factory, display)
-    params["position"] = 1
-    web_game.play(params)
-    expect(web_game.send(:winning_mark_found?)).to be(false)
+    web_game = WebGameCreate.new(params, player_factory_spy, display)
+    allow(display).to receive(:display_board).with(web_game.game.board)
+    expect(display.board.board_cells).to eq(board_cells)
   end
 
   def set_player_ready_state(player1_is_ready: false, player2_is_ready: false)
-    allow(player_factory).to receive(:get_players_for_game_type).and_return(Hash[TicTacToe::Mark::X, player1, TicTacToe::Mark::O, player2])
+    allow(player_factory_spy).to receive(:get_players_for_game_type).and_return(Hash[TicTacToe::Mark::X, player1, TicTacToe::Mark::O, player2])
     allow(player1).to receive(:is_ready?).and_return(player1_is_ready)
     allow(player2).to receive(:is_ready?).and_return(player2_is_ready)
   end

--- a/spec/web_game_play_spec.rb
+++ b/spec/web_game_play_spec.rb
@@ -1,0 +1,31 @@
+require "web_game_play"
+require "web_game_create"
+require "web_player_factory"
+require "web_display"
+
+RSpec.describe WebGamePlay do
+  let(:web_game_spy) { instance_spy(WebGameCreate) }
+  let(:display) { WebDisplay.new }
+  let(:three_by_three) { "THREE_BY_THREE" }
+  let(:human_v_human) { "HVH" }
+  let(:params) { { "dimension"  => three_by_three, "game_type" => human_v_human } }
+
+  it "plays a move" do
+    session_stub = {}
+    params["position"] = 1
+    web_game = WebGamePlay.new(params, WebGameCreate.new(params, WebPlayerFactory.new(display), display))
+    expect(display.board_cells).to eq([["X", nil, nil], [nil, nil, nil], [nil, nil, nil]])
+  end
+
+  it "tells web_display there is a result" do
+    result_board = [["X", "O", "X"], ["X", "O", "O"], ["O", "X", "X"]]
+    game_spy = instance_spy(TicTacToe::Game)
+    display_spy = instance_spy(WebDisplay)
+    allow(web_game_spy).to receive(:game).and_return(game_spy)
+    allow(web_game_spy).to receive(:display).and_return(display_spy)
+    allow(game_spy).to receive(:play_turns).and_return(result_board)
+    expect(display_spy).to receive(:display_result)
+    web_game = WebGamePlay.new(params, web_game_spy).web_game
+  end
+end
+


### PR DESCRIPTION
@maikon
@jsuchy

Required lots of spec changes as functionality moved from one class to
another.

Also, moved the 'session' manipulation out of WebGameCreate and into
WebApp. This is a trade off as session has to dig in to WebDisplay instance
to get the latest board_cells
